### PR TITLE
fix Dockerfile, download online sources, install build dependencies, generate SRPM, ...

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM centos
+MAINTAINER Alan Franzoni username@franzoni.eu
+RUN yum install -y rpm-build rpmdevtools yum-utils make gcc

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,4 +1,0 @@
-FROM alanfranz/drb-epel-6-x86-64
-MAINTAINER Alan Franzoni username@franzoni.eu
-ADD uuid.spec /tmp/uuid.spec
-RUN yum-builddep /tmp/uuid.spec

--- a/README.md
+++ b/README.md
@@ -11,18 +11,27 @@ It's designed to be a very small and hackable wrapper to help in rpm building, a
 
 Must have [docker](https://www.docker.io/) installed and properly configured. The user running the build must be able to properly use docker.
 
+Then you have to create a Docker image that will be reused for each build.
+
+<pre>
+git clone https://github.com/alanfranz/docker-rpm-builder.git
+cd docker-rpm-builder
+docker build -t docker-rpm-builder .
+</pre>
+
+
 ## Building a binary RPM from a directory
 
 The directory should contain:
 * the .spec file
-* all files which are marked as **SourceX** in the spec file;
+* all local files which are marked as **SourceX** or **PatchX** in the spec file;
 * optionally, a yum.conf file (will be used while fetching deps and building the rpm in the docker guest)
 * optionally, any number of .repo files (will be placed in /etc/yum.repos.d of the docker guest)
 
 ### Usage
 
 <pre>
-docker-build-binary-rpm-from-dir.sh IMAGETAG SRCDIR [ADDITIONAL_DOCKER_OPTIONS]
+docker-build-binary-rpm-from-dir.sh docker-rpm-builder FULL_PATH_TO_SRC_DIR [ADDITIONAL_DOCKER_OPTIONS]
 </pre>
 
 For building for Centos 6 with EPEL enabled there's a trusted build [here](https://index.docker.io/u/alanfranz/drb-epel-6-x86-64/) ([github source](https://github.com/alanfranz/docker-rpm-builder-configurations))

--- a/rpmbuild-in-docker.sh
+++ b/rpmbuild-in-docker.sh
@@ -2,7 +2,12 @@
 set -ex
 echo "starting $0"
 SPEC=$(ls /src/*.spec | head -n 1)
+mkdir -p /docker-rpm-build-root/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
 cp -t /docker-rpm-build-root/SOURCES -r /src/*
-rpmbuild -bb $SPEC
+chown -R root. /src
+yum-builddep "$SPEC" -y
+spectool --directory /docker-rpm-build-root/SOURCES -g "$SPEC"
+rpmbuild -ba --define="_topdir /docker-rpm-build-root" "$SPEC"
+cp -r /docker-rpm-build-root/SRPMS /src
 cp -r /docker-rpm-build-root/RPMS /src
 echo "Done"


### PR DESCRIPTION
Hi,

I tried to use docker-rpm-builder, unfortunately I has some issues:
- Dockerfile reference file outside this repo
- Build dependencies not fetched
- rpmbuild not using /docker-rpm-build-root

I make it works with this Pull Request.

Moreover, I added some features that I think would be interesting for the project:
- Download SourceXXX ou PatchXX if provided as an url in the spec file
- Generate SRPM
- Create a Dockerfile based on an official Centos
