### PR TITLE
Remove containers on exit

### DIFF
--- a/drb/commands/dir.py
+++ b/drb/commands/dir.py
@@ -135,8 +135,8 @@ def dir(image, source_directory, target_directory, additional_docker_options, do
     try:
         additional_docker_options = " ".join(additional_docker_options)
         dockerscripts = getpath("drb/dockerscripts")
-        rpms_inner_dir = sp("{dockerexec} run {image} rpm --eval %{{_rpmdir}}", **locals()).strip()
-        sources_inner_dir = sp("{dockerexec} run {image} rpm --eval %{{_sourcedir}}", **locals()).strip()
+        rpms_inner_dir = sp("{dockerexec} run --rm {image} rpm --eval %{{_rpmdir}}", **locals()).strip()
+        sources_inner_dir = sp("{dockerexec} run --rm {image} rpm --eval %{{_sourcedir}}", **locals()).strip()
         spawn_func("{dockerexec} run {additional_docker_options} -v {dockerscripts}:/dockerscripts -v {source_directory}:{sources_inner_dir} -v {target_directory}:{rpms_inner_dir} {bashonfail_options} -w /dockerscripts {image}  ./rpmbuild-dir-in-docker.sh {serialized_options}", **locals())
     finally:
         if deletespec:

--- a/drb/commands/selftest.py
+++ b/drb/commands/selftest.py
@@ -40,7 +40,7 @@ def short_test():
 
     dockerexec = which("docker")
     testpath = getpath("drb/test")
-    result = sp("{dockerexec} run -v {testpath}:/testpath phusion/baseimage /bin/bash -c 'cat /testpath/everythinglooksgood.txt'", **locals())
+    result = sp("{dockerexec} run --rm -v {testpath}:/testpath phusion/baseimage /bin/bash -c 'cat /testpath/everythinglooksgood.txt'", **locals())
     if result.strip() != "everything looks good":
         click.echo("Basic self test failed: docker run failed. Checklist:\n\nVerify the docker service is running\n"
                    "Verify the 'docker' group exists and your user belongs to it\n"

--- a/drb/commands/srcrpm.py
+++ b/drb/commands/srcrpm.py
@@ -104,8 +104,8 @@ def srcrpm(image, srcrpm, target_directory, additional_docker_options, verify_si
 
     try:
         additional_docker_options = internal_docker_options + " ".join(additional_docker_options)
-        srpms_inner_dir = sp("{dockerexec} run {image} rpm --eval %{{_srcrpmdir}}", **locals()).strip()
-        rpms_inner_dir = sp("{dockerexec} run {image} rpm --eval %{{_rpmdir}}", **locals()).strip()
+        srpms_inner_dir = sp("{dockerexec} run --rm {image} rpm --eval %{{_srcrpmdir}}", **locals()).strip()
+        rpms_inner_dir = sp("{dockerexec} run --rm {image} rpm --eval %{{_rpmdir}}", **locals()).strip()
         spawn_func("{dockerexec} run {additional_docker_options} -v {dockerscripts}:/dockerscripts -v {srpms_temp}:{srpms_inner_dir} -v {target_directory}:{rpms_inner_dir}"
            " -w /dockerscripts {image} ./rpmbuild-srcrpm-in-docker.sh {serialized_options}", **locals())
     finally:


### PR DESCRIPTION
Remove containers after they exit when performing environment introspection.
The user can pass `--rm` when building the RPM so that they can inspect the
failed environment if necessary.