### PR TITLE
Allow for providing uid/gid

### DIFF
--- a/drb/commands/dir.py
+++ b/drb/commands/dir.py
@@ -53,7 +53,13 @@ _HELP = """Builds a binary RPM from a directory. Uses `docker run` under the hoo
     --always-pull: if passed, a `docker pull` for the latest
     image version from Docker Hub (or other configured endpoint) is performed. Please note that
     any error that may arise from the operation is currently ignored.
-
+    
+    --uid: if passed uses the given value as the uid when creating a local user
+    to satisfy rpmbuild's need for a valid uid; defaults to calling user's uid.
+    
+    --gid: if passed uses the given value as the gid when creating a local group
+    to satisfy rpmbuild's need for a valid gid; defaults to calling user's gid.
+    
     Examples:
 
     - in this scenario we use no option of ours but we add an option to be forwarded to docker:
@@ -77,8 +83,10 @@ _logger = logging.getLogger("drb.commands.dir")
 @click.option("--bash-on-failure", is_flag=True)
 @click.option("--sign-with", nargs=1, type=click.Path(exists=True, dir_okay=False, resolve_path=True))
 @click.option("--always-pull", is_flag=True)
+@click.option("--uid", type=int, help="uid of calling user", default=os.getuid())
+@click.option("--gid", type=int, help="gid of calling user", default=os.getgid())
 def dir(image, source_directory, target_directory, additional_docker_options, download_sources=False,
-        bash_on_failure=False, sign_with=None, always_pull=False):
+        bash_on_failure=False, sign_with=None, always_pull=False, uid=-1, gid=-1):
 
 
     # TODO: let spectemplate and/or spec be optional parameters
@@ -127,8 +135,6 @@ def dir(image, source_directory, target_directory, additional_docker_options, do
 
     if always_pull:
         pull(dockerexec, image)
-    uid = os.getuid()
-    gid = os.getgid()
 
     serialized_options = serialize({"CALLING_UID": uid, "CALLING_GID": gid, "BASH_ON_FAIL":bashonfail, "GPG_PRIVATE_KEY": sign_with_encoded})
 

--- a/drb/commands/srcrpm.py
+++ b/drb/commands/srcrpm.py
@@ -47,6 +47,12 @@ _HELP = """Builds a binary RPM from .src.rpm file.
     image version from Docker Hub (or other configured endpoint) is performed. Please note that
     any error that may arise from the operation is currently ignored.
 
+    --uid: if passed uses the given value as the uid when creating a local user
+    to satisfy rpmbuild's need for a valid uid; defaults to calling user's uid.
+    
+    --gid: if passed uses the given value as the gid when creating a local group
+    to satisfy rpmbuild's need for a valid gid; defaults to calling user's gid.
+    
     Examples:
 
     - in this scenario we use no option of ours but we add an option to be forwarded to docker:
@@ -69,8 +75,10 @@ _logger = logging.getLogger("drb.commands.srcrpm")
 @click.option("--bash-on-failure", is_flag=True)
 @click.option("--sign-with", nargs=1, type=click.Path(exists=True, dir_okay=False, resolve_path=True))
 @click.option("--always-pull", is_flag=True)
+@click.option("--uid", type=int, help="uid of calling user", default=os.getuid())
+@click.option("--gid", type=int, help="gid of calling user", default=os.getgid())
 def srcrpm(image, srcrpm, target_directory, additional_docker_options, verify_signature=False, bash_on_failure=False,
-           sign_with=None, always_pull=False):
+           sign_with=None, always_pull=False, uid=-1, gid=-1):
     _logger.info("Now building %(srcrpm)s on image %(image)s", locals())
     if not os.path.exists(target_directory):
         os.mkdir(target_directory)
@@ -81,8 +89,6 @@ def srcrpm(image, srcrpm, target_directory, additional_docker_options, verify_si
     shutil.copy(srcrpm, srpms_temp)
     internal_docker_options = set()
     srcrpm_basename = os.path.basename(srcrpm)
-    uid = os.getuid()
-    gid = os.getgid()
     rpmbuild_options = "" if verify_signature else "--nosignature"
 
     bashonfail = ""


### PR DESCRIPTION
The default uid/gid detection works fine if you're running on the same host as
the docker daemon, but that's not the case with boot2docker, which provides
another layer of indirection.

On my Mac, my uid/gid is 600/20.  In the boot2docker vm, the docker user is
1000/50.  When using VirtualBox to share files from my Mac's home directory to
the VM (and hence to Docker) the value from os.getuid() doesn't match the owning
uid of some files, so rpmbuild fails.