### PR TITLE
Implement optional yum cache to speed up builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,6 @@ DNS in the docker config file.
 
 ## TODOS and ideas
 * General refactor: remove code duplication, improve setup, etc. - things are currently quite messed up.
-* Support some way to cache build dependencies between builds for the same package (commit after run? commit after build-dep?)
 * DEB package
 * Refactor bash-based test into python-based ones, even when spawning processes
 * Find a better solution than 'spectool' for downloading sources.

--- a/drb/commands/srcrpm.py
+++ b/drb/commands/srcrpm.py
@@ -47,6 +47,10 @@ _HELP = """Builds a binary RPM from .src.rpm file.
     image version from Docker Hub (or other configured endpoint) is performed. Please note that
     any error that may arise from the operation is currently ignored.
 
+    --yum-cache: if passed, the given location is mounted at /var/cache/yum in
+    the container; subsequent invocations will use this cache instead of
+    downloading packages again.
+    
     Examples:
 
     - in this scenario we use no option of ours but we add an option to be forwarded to docker:
@@ -69,8 +73,9 @@ _logger = logging.getLogger("drb.commands.srcrpm")
 @click.option("--bash-on-failure", is_flag=True)
 @click.option("--sign-with", nargs=1, type=click.Path(exists=True, dir_okay=False, resolve_path=True))
 @click.option("--always-pull", is_flag=True)
+@click.option("--yum-cache", nargs=1, type=click.Path(exists=True, dir_okay=True, resolve_path=True), help="path to local yum cache")
 def srcrpm(image, srcrpm, target_directory, additional_docker_options, verify_signature=False, bash_on_failure=False,
-           sign_with=None, always_pull=False):
+           sign_with=None, always_pull=False, yum_cache=None):
     _logger.info("Now building %(srcrpm)s on image %(image)s", locals())
     if not os.path.exists(target_directory):
         os.mkdir(target_directory)
@@ -106,8 +111,18 @@ def srcrpm(image, srcrpm, target_directory, additional_docker_options, verify_si
         additional_docker_options = internal_docker_options + " ".join(additional_docker_options)
         srpms_inner_dir = sp("{dockerexec} run --rm {image} rpm --eval %{{_srcrpmdir}}", **locals()).strip()
         rpms_inner_dir = sp("{dockerexec} run --rm {image} rpm --eval %{{_rpmdir}}", **locals()).strip()
-        spawn_func("{dockerexec} run {additional_docker_options} -v {dockerscripts}:/dockerscripts -v {srpms_temp}:{srpms_inner_dir} -v {target_directory}:{rpms_inner_dir}"
-           " -w /dockerscripts {image} ./rpmbuild-srcrpm-in-docker.sh {serialized_options}", **locals())
+        
+        spawn_func(" ".join([
+            "{dockerexec} run",
+            "{additional_docker_options}",
+            "-v {dockerscripts}:/dockerscripts", 
+            "-v {srpms_temp}:{srpms_inner_dir}",
+            "-v {target_directory}:{rpms_inner_dir}",
+            "-v {yum_cache}:/var/cache/yum" if yum_cache is not None else "",
+            "-w /dockerscripts",
+            "{image}",
+            "/bin/bash rpmbuild-dir-in-docker.sh {serialized_options}",
+        ]), **locals())
     finally:
         shutil.rmtree(srpms_temp)
 

--- a/drb/dockerscripts/rpm-setup-deps.sh
+++ b/drb/dockerscripts/rpm-setup-deps.sh
@@ -3,4 +3,4 @@ set -ex
 echo "starting $0"
 SOURCE_DIR=$(rpm --eval %{_sourcedir})
 SPEC=$(ls ${SOURCE_DIR}/*.spec | head -n 1)
-yum-builddep --nogpgcheck ${SPEC} || /bin/bash
+yum-builddep --setopt=keepcache=1 --nogpgcheck ${SPEC} || /bin/bash

--- a/drb/dockerscripts/rpmbuild-srcrpm-in-docker.sh
+++ b/drb/dockerscripts/rpmbuild-srcrpm-in-docker.sh
@@ -27,7 +27,7 @@ useradd -g ${CALLING_GID} -u ${CALLING_UID} myuser || /bin/true
 
 # we don't check the gpg signature at this time, we don't really care;
 # if the signature check fails it will fail later.
-yum-builddep --nogpgcheck "${SRPMS_DIR}/${SRCRPM}"
+yum-builddep --setopt=keepcache=1 --nogpgcheck "${SRPMS_DIR}/${SRCRPM}"
 
 if [ -n "${GPG_PRIVATE_KEY}" ]
 then


### PR DESCRIPTION
This adds a new `--yum-cache` option that provides a local path for yum to cache
downloaded RPMs and metadata.  This greatly speeds up builds by allowing
already-downloaded packages (sometimes several hundred megs worth!) to be
reused.