### PR TITLE
Small fixes for downloadsources.py

### DIFF
--- a/drb/downloadsources.py
+++ b/drb/downloadsources.py
@@ -24,7 +24,7 @@ def get_spec_with_resolved_macros(specfilename, target_image):
     lines_upto_prep =list(takewhile(lambda line: not line.startswith("%prep"),
                                     codecs.open(specfilename, encoding="utf-8")))
 
-    tempspec = NamedTemporaryFile(suffix=".spec")
+    tempspec = NamedTemporaryFile(suffix=".spec", mode="w+")
     tempspec.writelines(lines_upto_prep)
     tempspec.write("%prep\n")
     tempspec.write("cat<<__EOF__\n")

--- a/drb/downloadsources.py
+++ b/drb/downloadsources.py
@@ -33,8 +33,8 @@ def get_spec_with_resolved_macros(specfilename, target_image):
     tempspec.flush()
 
     try:
-        rpmbuild = which("rpmbuild")
         docker = which("docker")
+        rpmbuild = sp("{docker} run --rm {target_image} which rpmbuild", **locals()).strip()
         with_macros = sp("{docker} run -v {tempspec.name}:{tempspec.name}:ro --rm {target_image} {rpmbuild} --nodeps -bp {tempspec.name}", **locals())
     finally:
         tempspec.close()


### PR DESCRIPTION
'docker-rpm-build selftest' didn't pass for me on ArchLinux. This small pull
request fixes this.
