### PR TITLE
Added support for arbitrary rpmbuild arguments

### DIFF
--- a/drb/commands/dir.py
+++ b/drb/commands/dir.py
@@ -94,8 +94,9 @@ _logger = logging.getLogger("drb.commands.dir")
 @click.option("--target-ownership", type=click.STRING, default="{0}:{1}".format(os.getuid(), os.getgid()))
 @click.option('--verbose', is_flag=True, default=False)
 @click.option('--preserve-container', is_flag=True, default=False)
+@click.option("--rpmbuild-options", type=click.STRING, default="")
 def dir(image, source_directory, target_directory, additional_docker_options, download_sources,
-        bash_on_failure, sign_with, always_pull, target_ownership, verbose, preserve_container):
+        bash_on_failure, sign_with, always_pull, target_ownership, verbose, preserve_container, rpmbuild_options):
     configure_root_logger(verbose)
 
     docker = Docker().image(image)
@@ -137,7 +138,7 @@ def dir(image, source_directory, target_directory, additional_docker_options, do
     mkdir_p(target_directory)
     docker.additional_options(*additional_docker_options).bindmount_file(specfile, os.path.join(specs_inner_dir, specname)).bindmount_dir(dockerscripts, "/dockerscripts") \
         .bindmount_dir(source_directory, sources_inner_dir).bindmount_dir(target_directory, rpms_inner_dir, read_only=False).workdir("/dockerscripts") \
-        .env("CALLING_UID", str(uid)).env("CALLING_GID", str(gid)).env("BASH_ON_FAIL", bashonfail) \
+        .env("CALLING_UID", str(uid)).env("CALLING_GID", str(gid)).env("BASH_ON_FAIL", bashonfail).env("RPMBUILD_OPTIONS", rpmbuild_options) \
         .cmd_and_args("./rpmbuild-dir-in-docker.sh")
 
 

--- a/drb/commands/srcrpm.py
+++ b/drb/commands/srcrpm.py
@@ -83,8 +83,9 @@ _logger = logging.getLogger("drb.commands.srcrpm")
 @click.option("--target-ownership", type=click.STRING, default="{0}:{1}".format(os.getuid(), os.getgid()))
 @click.option('--verbose', is_flag=True, default=False)
 @click.option('--preserve-container', is_flag=True, default=False)
+@click.option('--rpmbuild-options', type=click.STRING, default="")
 def srcrpm(image, srcrpm, target_directory, additional_docker_options, verify_signature, bash_on_failure,
-           sign_with, always_pull, target_ownership, verbose, preserve_container):
+           sign_with, always_pull, target_ownership, verbose, preserve_container, rpmbuild_options):
     configure_root_logger(verbose)
 
     docker = Docker().image(image)
@@ -98,7 +99,8 @@ def srcrpm(image, srcrpm, target_directory, additional_docker_options, verify_si
     srpms_inner_dir = docker.cmd_and_args("rpm", "--eval", "%{_srcrpmdir}").do_run()
     rpms_inner_dir = docker.cmd_and_args("rpm", "--eval", "%{_rpmdir}").do_run()
     uid, gid = parse_ownership(target_ownership)
-    rpmbuild_options = "" if verify_signature else "--nosignature"
+    if not verify_signature and "--nosignature" not in rpmbuild_options:
+        rpmbuild_options += " --nosignature"
     dockerscripts = getpath("drb/dockerscripts")
     docker.additional_options(*additional_docker_options)
     if sign_with:

--- a/drb/dockerscripts/rpmbuild-dir-in-docker.sh
+++ b/drb/dockerscripts/rpmbuild-dir-in-docker.sh
@@ -40,7 +40,7 @@ then
     echo -e "%_gpg_name ${KEYNAME}\n%_signature gpg" > ${HOME}/.rpmmacros
 	
 	exitcode=0
-    rpmbuild_out="$(rpmbuild -bb $SPEC 2>&1)" || { exitcode="$?" ; /bin/true ; }
+    rpmbuild_out="$(eval rpmbuild -bb $RPMBUILD_OPTIONS $SPEC 2>&1)" || { exitcode="$?" ; /bin/true ; }
     if [ "${exitcode}" -ne 0 ]; then
 			if [ "bashonfail" == "${BASH_ON_FAIL}" ]; then
 				# if the build is interactive, we can see what's printed in the current log, no need to reprint.
@@ -70,6 +70,6 @@ then
 	fi
 else
     echo "Running without RPM signing"
-    rpmbuild -bb $SPEC || { [ "bashonfail" == "${BASH_ON_FAIL}" ] && { echo "Build failed, spawning a shell" ; /bin/bash ; exit 1; } || exit 1 ; }
+    eval rpmbuild -bb $RPMBUILD_OPTIONS $SPEC || { [ "bashonfail" == "${BASH_ON_FAIL}" ] && { echo "Build failed, spawning a shell" ; /bin/bash ; exit 1; } || exit 1 ; }
 fi
 echo "Done"

--- a/drb/dockerscripts/rpmbuild-srcrpm-in-docker.sh
+++ b/drb/dockerscripts/rpmbuild-srcrpm-in-docker.sh
@@ -41,7 +41,7 @@ then
     echo -e "%_gpg_name ${KEYNAME}\n%_signature gpg" > ${HOME}/.rpmmacros
 
 	exitcode=0
-    rpmbuild_out="$(rpmbuild --rebuild ${RPMBUILD_OPTIONS} "${SRPMS_DIR}/${SRCRPM}" 2>&1)" || { exitcode="$?" ; /bin/true ; }
+    rpmbuild_out="$(eval rpmbuild --rebuild ${RPMBUILD_OPTIONS} "${SRPMS_DIR}/${SRCRPM}" 2>&1)" || { exitcode="$?" ; /bin/true ; }
     if [ "${exitcode}" -ne 0 ]; then
 			if [ "bashonfail" == "${BASH_ON_FAIL}" ]; then
 				# if the build is interactive, we can see what's printed in the current log, no need to reprint.
@@ -70,7 +70,7 @@ then
 		exit ${exitcode}
 	fi
 else
-    rpmbuild --rebuild ${RPMBUILD_OPTIONS} "${SRPMS_DIR}/${SRCRPM}" || { [ "bashonfail" == "$BASH_ON_FAIL" ] && { echo "Build failed, spawning a shell" ; /bin/bash ; exit 1; } || exit 1 ; }
+    eval rpmbuild --rebuild ${RPMBUILD_OPTIONS} "${SRPMS_DIR}/${SRCRPM}" || { [ "bashonfail" == "$BASH_ON_FAIL" ] && { echo "Build failed, spawning a shell" ; /bin/bash ; exit 1; } || exit 1 ; }
 fi
 
 echo "Done"


### PR DESCRIPTION
This solves issue #22.  I had to throw eval in there otherwise it didn't pick up arguments passed in with quotes.

Here's a sample command I ran and it generated the RPMs in the format I was expecting.

```
docker-rpm-builder dir \
    --rpmbuild-options "-D 'dist .el7' -D 'release 201603251909'" \
    --verbose \
    alanfranz/drb-epel-7-x86-64:latest \
    . `pwd`/rpms
```

Output
`nagios-plugins-2.1.1-201603251909.el7.x86_64.rpm`
