### PR TITLE
Add transparent proxy support

### DIFF
--- a/drb/proxy_config.py
+++ b/drb/proxy_config.py
@@ -1,0 +1,14 @@
+
+import os
+
+PROXY_VARIABLES = ["HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy", "NO_PROXY", "no_proxy"]
+
+def configure_proxies(logger, docker):
+    configured = False
+    for var in PROXY_VARIABLES:
+        if var in os.environ:
+            docker.env(var, os.environ[var])
+            configured = True
+
+    if configured:
+        logger.info("Set proxy variables for build.")


### PR DESCRIPTION
If common proxy variables are set in the user's environment,
copy them into the container's environment. Can be disabled
with the --no-proxy flag.
