### PR TITLE
fix: do not use tmpfs directive

### DIFF
--- a/drb/commands/dir.py
+++ b/drb/commands/dir.py
@@ -113,7 +113,7 @@ def dir(image, source_directory, target_directory, additional_docker_options, do
         enable_source_overlay):
     configure_root_logger(verbose)
 
-    docker = Docker().image(image).tmpfs("/tmp")
+    docker = Docker().image(image)
     if not preserve_container:
         docker.rm()
 


### PR DESCRIPTION
If the build project use /tmp folder (like pip to download/compile libs) 50Mb, docker defaults, are too small.

Another fix is specify the dimension of /tmp with --tmpfs /tmp:rw,size=1G.

Thanks
