### PR TITLE
Enh: make bindings automagically work on SELinux systems

### DIFF
--- a/drb/commands/dir.py
+++ b/drb/commands/dir.py
@@ -91,7 +91,7 @@ _HELP = """Builds a binary RPM from a directory. Uses `docker run` under the hoo
     its content will be copied where it's meant to be used (i.e. ${HOME}/.rpmmacros). Please remember you should use an
     absolute path for the host macros file:
 
-    docker-rpm-builder dir a682b68bbaba . /tmp/rpms -- --volume=/home/user/my.macros:/rpmmacros:ro
+    docker-rpm-builder dir a682b68bbaba . /tmp/rpms -- --volume=/home/user/my.macros:/rpmmacros:ro,Z
 
     """
 

--- a/drb/commands/srcrpm.py
+++ b/drb/commands/srcrpm.py
@@ -72,7 +72,7 @@ _HELP = """Builds a binary RPM from .src.rpm file.
     dockerscripts directory in the source if you want to know more) - if bind a /rpmmacros file inside the container,
     it will be copied where it's meant to be used:
 
-    docker-rpm-builder dir a682b68bbaba . /tmp/rpms -- --volume=/home/user/my.macros:/rpmmacros:ro
+    docker-rpm-builder dir a682b68bbaba . /tmp/rpms -- --volume=/home/user/my.macros:/rpmmacros:ro,Z
     """
 
 _logger = logging.getLogger("drb.commands.srcrpm")

--- a/drb/docker.py
+++ b/drb/docker.py
@@ -127,7 +127,7 @@ class Docker(object):
         precondition(os.path.isdir(host_dir), "host_dir must be a directory")
         precondition(os.path.isabs(guest_dir), "guest_dir must be absolute")
 
-        option = "--volume={0}:{1}{2}".format(pipes.quote(os.path.abspath(host_dir)), pipes.quote(guest_dir), ("", ":ro")[read_only])
+        option = "--volume={0}:{1}:Z{2}".format(pipes.quote(os.path.abspath(host_dir)), pipes.quote(guest_dir), ("", ",ro")[read_only])
         self._options.append(option)
         return self
 
@@ -136,7 +136,7 @@ class Docker(object):
         precondition(os.path.isfile(host_file), "host_file must be a file")
         precondition(os.path.isabs(guest_file), "guest_file must be absolute")
 
-        option = "--volume={0}:{1}{2}".format(pipes.quote(os.path.abspath(host_file)), pipes.quote(guest_file), ("", ":ro")[read_only])
+        option = "--volume={0}:{1}:Z{2}".format(pipes.quote(os.path.abspath(host_file)), pipes.quote(guest_file), ("", ",ro")[read_only])
         self._options.append(option)
         return self
 


### PR DESCRIPTION
This uses Docker's relatively-new "Z" option on volume bindings to automatically set up SELinux labeling on mounted directories if needed. I haven't checked which versions of Docker support this, etc.