### PR TITLE
fix debian stretch repo string

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ deb https://dl.bintray.com/alanfranz/drb-v1-debian-jessie jessie main
 or
 
 ```
-deb https://dl.bintray.com/alanfranz/drb-v1-debian-stretch jessie main
+deb https://dl.bintray.com/alanfranz/drb-v1-debian-stretch stretch main
 ```
 
 


### PR DESCRIPTION
This fixes an error in the README document on how to install on debian stretch.